### PR TITLE
Fix/exports and display none on block

### DIFF
--- a/src/components/Block.ts
+++ b/src/components/Block.ts
@@ -4,7 +4,7 @@ import { styled, Colour, withMargin, withPadding } from '../shared';
 export interface BlockProps {
   alignItems?: 'center' | 'start' | 'end';
   background?: Colour;
-  display?: 'inline' | 'block' | 'inline-block' | 'flex';
+  display?: 'inline' | 'block' | 'inline-block' | 'flex' | 'none';
   flex?: string;
   flexDirection?: 'row' | 'row-reverse' | 'column' | 'column-reverse';
   flexGrow?: number;

--- a/src/components/index.ts
+++ b/src/components/index.ts
@@ -4,4 +4,5 @@ export { default as Card } from './Card';
 export { default as Heading } from './Heading';
 export { default as Text } from './Text';
 export { default as TextBox } from './TextBox';
+export { default as TextField } from './TextField';
 export { default as Toggle } from './Toggle';


### PR DESCRIPTION
This addresses two issues where Block couldn't have a `none` display mode and `TextField` wasn't exported from the `components/index.ts`.